### PR TITLE
Add field option model

### DIFF
--- a/lib/planning_center/models/base.rb
+++ b/lib/planning_center/models/base.rb
@@ -39,8 +39,8 @@ module PlanningCenter
         )
       end
 
-      def where(params = {})
-        params = { where: params }
+      def where(include: [], **params)
+        params = { where: params, include: include }
         response = client.get(base_endpoint, params)['data']
 
         response.map do |hsh|

--- a/lib/planning_center/models/field_datum.rb
+++ b/lib/planning_center/models/field_datum.rb
@@ -3,7 +3,7 @@
 module PlanningCenter
   class FieldDatum < Base
     IMMUTABLE_FIELDS = %i[id file file_content_type file_name file_size
-                          person_id].freeze
+                          person_id field_option_id].freeze
     FIELDS = %i[field_definition_id value].freeze
 
     attribute :id, :integer
@@ -14,6 +14,7 @@ module PlanningCenter
     attribute :file_size, :integer
     attribute :person_id, :integer
     attribute :value, :string
+    attribute :field_option_id, :integer
 
     FIELDS.each do |attr|
       define_method "#{attr}=" do |value|

--- a/lib/planning_center/models/field_definition.rb
+++ b/lib/planning_center/models/field_definition.rb
@@ -35,8 +35,8 @@ module PlanningCenter
       Tab.find(tab_id)
     end
 
-    def field_options
-      FieldOption.all(field_definition_id: id)
+    def field_options(params = {})
+      FieldOption.where(field_definition_id: id, **params)
     end
 
     private

--- a/lib/planning_center/models/field_definition.rb
+++ b/lib/planning_center/models/field_definition.rb
@@ -5,6 +5,9 @@ module PlanningCenter
     IMMUTABLE_FIELDS = %i[id tab_id].freeze
     FIELDS = %i[config data_type deleted_at name sequence slug].freeze
 
+    DATA_TYPES = %w[text string date file boolean
+                    select checkboxes number header].freeze
+
     attribute :id, :integer
     attribute :config, :string
     attribute :data_type, :string
@@ -23,12 +26,17 @@ module PlanningCenter
 
     define_attribute_methods(*FIELDS)
 
-    validates :data_type, :name, :tab_id, presence: true
+    validates :name, :tab_id, presence: true
+    validates :data_type, inclusion: { in: DATA_TYPES }, presence: true
 
     # belongs_to :tab
 
     def tab
       Tab.find(tab_id)
+    end
+
+    def field_options
+      FieldOption.all(field_definition_id: id)
     end
 
     private

--- a/lib/planning_center/models/field_option.rb
+++ b/lib/planning_center/models/field_option.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module PlanningCenter
+  class FieldOption < Base
+    IMMUTABLE_FIELDS = %i[id field_definition_id].freeze
+    FIELDS = %i[value sequence].freeze
+
+    attribute :id, :integer
+    attribute :value, :string
+    attribute :sequence, :integer
+    attribute :field_definition_id, :integer
+
+    FIELDS.each do |attr|
+      define_method "#{attr}=" do |value|
+        public_send "#{attr}_will_change!"
+        super(value)
+      end
+    end
+
+    define_attribute_methods(*FIELDS)
+
+    validates :value, presence: true
+
+    # belongs_to :field_definition
+
+    class << self
+      attr_accessor :field_definition_id
+
+      def all(field_definition_id:)
+        self.field_definition_id = field_definition_id
+
+        super()
+      end
+
+      def where(field_definition_id:, **params)
+        self.field_definition_id = field_definition_id
+
+        super(params)
+      end
+
+      def find(id, field_definition_id:)
+        self.field_definition_id = field_definition_id
+
+        super(id)
+      end
+
+      def create(field_definition_id:, **attributes, &block)
+        self.field_definition_id = field_definition_id
+
+        super(attributes, &block)
+      end
+
+      def base_endpoint
+        "people/v2/field_definitions/#{field_definition_id}/field_options"
+      end
+    end
+
+    def field_definition
+      FieldDefinition.find(field_definition_id)
+    end
+  end
+end

--- a/lib/planning_center/models/person.rb
+++ b/lib/planning_center/models/person.rb
@@ -54,7 +54,7 @@ module PlanningCenter
     validates :first_name, :last_name, presence: true
 
     def field_data(params = {})
-      params = { where: params }
+      params = { where: params, include: [:field_option] }
       response = client.get("people/v2/people/#{id}/field_data", params)['data']
 
       response.map do |hsh|


### PR DESCRIPTION
This PR adds a `FieldOption` model which is used to create the checkboxes we need for syncing both lists and tags.