### PR TITLE
Fix person model

### DIFF
--- a/lib/planning_center/models/person.rb
+++ b/lib/planning_center/models/person.rb
@@ -4,7 +4,7 @@ module PlanningCenter
   class Person < Base
     IMMUTABLE_FIELDS = %i[id can_create_forms created_at demographic_avatar_url
                           directory_status name passed_background_check school_type
-                          updated_at].freeze
+                          updated_at can_email_lists].freeze
     FIELDS = %i[accounting_administrator anniversary avatar birthdate child
                 first_name gender given_name grade graduation_year inactivated_at
                 last_name medical_notes membership middle_name nickname
@@ -17,6 +17,7 @@ module PlanningCenter
     attribute :avatar, :string
     attribute :birthdate, :date
     attribute :can_create_forms, :boolean
+    attribute :can_email_lists, :boolean
     attribute :child, :boolean
     attribute :created_at, :datetime
     attribute :demographic_avatar_url, :string


### PR DESCRIPTION
Apparently Planning Center added a `can_email_lists` attribute to people which caused [this](https://appsignal.com/mortarstone/sites/5cd9995714ad661f1f141544/exceptions/incidents/3504) error.